### PR TITLE
Remove package_version from Lockbox names.

### DIFF
--- a/doit.sh
+++ b/doit.sh
@@ -15,7 +15,7 @@ torizoncore_builder_build ${server_config_dir_prefix}_update ${TDX_TOKEN}
 torizoncore_builder_build ${client_config_dir_prefix}_update ${TDX_TOKEN}
 torizoncore_builder_push  ${server_config_dir_prefix}_update ${package_version}
 torizoncore_builder_push  ${client_config_dir_prefix}_update ${package_version}
-torizoncore_builder_define_lockbox ${client_config_dir_prefix}_update ${TDX_TOKEN} ${package_version} ${EXPIRATION_DATE} ${client_machine}
-torizoncore_builder_define_lockbox ${server_config_dir_prefix}_update ${TDX_TOKEN} ${package_version} ${EXPIRATION_DATE} ${server_machine}
-torizoncore_builder_build_lockbox ${client_config_dir_prefix}_update ${package_version}
-torizoncore_builder_build_lockbox ${server_config_dir_prefix}_update ${package_version}
+torizoncore_builder_define_lockbox ${client_config_dir_prefix}_update ${TDX_TOKEN} ${EXPIRATION_DATE} ${client_machine}
+torizoncore_builder_define_lockbox ${server_config_dir_prefix}_update ${TDX_TOKEN} ${EXPIRATION_DATE} ${server_machine}
+torizoncore_builder_build_lockbox ${client_config_dir_prefix}_update
+torizoncore_builder_build_lockbox ${server_config_dir_prefix}_update


### PR DESCRIPTION
It is not intended to be part of the lockbox as the lockbox contains a package which has a version but the lockbox itself can be modified to upgrade the package; thus no need to store the version in the lockbox name

Signed-off-by: Drew Moseley <drew@moseleynet.net>